### PR TITLE
Sync the job name in docker-offline.yml with docker-boshrelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to include this release in an existing deployment you can add [docke
 When using the above template the images can be loaded into docker by running:
 
 ```
-bosh run errand fetch-containers
+bosh run errand fetch-containers-images
 ```
 
 ### Development

--- a/templates/docker-offline.yml
+++ b/templates/docker-offline.yml
@@ -1,6 +1,6 @@
 jobs:
   - <<: (( merge ))
-  - name: fetch-containers
+  - name: fetch-containers-images
     templates:
       - name: docker_load_images
         release: docker-broker-images
@@ -16,7 +16,7 @@ properties:
     tcp_address: 0.0.0.0
 
   broker:
-    fetch_images: false # use `bosh run errand fetch-containers` so broker is not blocked
+    fetch_images: false # use `bosh run errand fetch-containers-images` so broker is not blocked
 
 
   docker_broker_images:


### PR DESCRIPTION
In v20 of docker-boshrelease the job name changed to fetch-containers-images.
